### PR TITLE
Add Router::url() support to HTMX response methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.idea/
 /.vscode/
 /tmp/
+/.phpunit.cache/

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,30 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    colors="true"
-    processIsolation="false"
-    stopOnFailure="false"
-    bootstrap="tests/bootstrap.php"
-    >
-    <php>
-        <ini name="memory_limit" value="-1"/>
-        <ini name="apc.enable_cli" value="1"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         colors="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/bootstrap.php"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache">
+  <php>
+    <ini name="memory_limit" value="-1"/>
+    <ini name="apc.enable_cli" value="1"/>
+  </php>
 
-    <!-- Add any additional test suites you want to run here -->
-    <testsuites>
-        <testsuite name="CakeHtmx">
-            <directory>tests/TestCase/</directory>
-        </testsuite>
-    </testsuites>
+  <!-- Add any additional test suites you want to run here -->
+  <testsuites>
+    <testsuite name="CakeHtmx">
+      <directory>tests/TestCase/</directory>
+    </testsuite>
+  </testsuites>
 
-    <!-- Setup fixture extension -->
-    <extensions>
-        <extension class="Cake\TestSuite\Fixture\PHPUnitExtension" />
-    </extensions>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+  <!-- Source -->
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Controller/Component/HtmxComponent.php
+++ b/src/Controller/Component/HtmxComponent.php
@@ -6,6 +6,8 @@ namespace CakeHtmx\Controller\Component;
 use Cake\Controller\Component;
 use Cake\Event\Event;
 use Cake\Http\Response;
+use Cake\Routing\Router;
+use Psr\Http\Message\UriInterface;
 
 /**
  * Htmx component
@@ -176,12 +178,12 @@ class HtmxComponent extends Component
     /**
      * Do a client-side redirect that does not do a full page reload
      *
-     * @param string $url Where to redirect
+     * @param \Psr\Http\Message\UriInterface|array|string|null $url Where to redirect
      * @return \Cake\Http\Response|null
      */
-    public function location(string $url): ?Response
+    public function location(UriInterface|array|string|null $url): ?Response
     {
-        $response = $this->getController()->getResponse()->withHeader('HX-Location', $url);
+        $response = $this->getController()->getResponse()->withHeader('HX-Location', Router::url($url));
         $this->getController()->setResponse($response);
 
         return $this->getController()->getResponse();
@@ -190,12 +192,12 @@ class HtmxComponent extends Component
     /**
      * Pushes a new url into the history stack
      *
-     * @param string $url Url to push
+     * @param \Psr\Http\Message\UriInterface|array|string|null $url Url to push
      * @return \Cake\Http\Response|null
      */
-    public function pushUrl(string $url): ?Response
+    public function pushUrl(UriInterface|array|string|null $url): ?Response
     {
-        $response = $this->getController()->getResponse()->withHeader('HX-Push-Url', $url);
+        $response = $this->getController()->getResponse()->withHeader('HX-Push-Url', Router::url($url));
         $this->getController()->setResponse($response);
 
         return $this->getController()->getResponse();
@@ -204,12 +206,12 @@ class HtmxComponent extends Component
     /**
      * Replaces the current URL in the location bar
      *
-     * @param string $url Url to replace
+     * @param \Psr\Http\Message\UriInterface|array|string|null $url Url to replace
      * @return \Cake\Http\Response|null
      */
-    public function replaceUrl(string $url): ?Response
+    public function replaceUrl(UriInterface|array|string|null $url): ?Response
     {
-        $response = $this->getController()->getResponse()->withHeader('HX-Replace-Url', $url);
+        $response = $this->getController()->getResponse()->withHeader('HX-Replace-Url', Router::url($url));
         $this->getController()->setResponse($response);
 
         return $this->getController()->getResponse();
@@ -323,13 +325,13 @@ class HtmxComponent extends Component
     /**
      * Trigger a client side redirect
      *
-     * @param string $to Where to redirect
+     * @param \Psr\Http\Message\UriInterface|array|string|null $to Where to redirect
      * @return \Cake\Http\Response|null
      */
-    public function redirect(string $to): ?Response
+    public function redirect(UriInterface|array|string|null $to): ?Response
     {
         $response = $this->getController()->getResponse();
-        $response = $response->withHeader('HX-Redirect', $to)->withStatus(200);
+        $response = $response->withHeader('HX-Redirect', Router::url($to))->withStatus(200);
         $this->getController()->setResponse($response);
 
         return $this->getController()->getResponse();


### PR DESCRIPTION
This PR updates the `HtmxComponent` to support flexible URL formats using CakePHP's `Router::url()` method for better integration with CakePHP's routing system.

**Updated Methods:**
- `location()`
- `pushUrl()`
- `replaceUrl()`
- `redirect()`

**Now Accepts:**
- String URLs: `'/posts/view/1'`
- Array routing: `['controller' => 'Posts', 'action' => 'view', 1]`
- PSR-7 UriInterface objects
- `null` values

**Example:**
```php
// Before - only strings
$this->Htmx->redirect('/posts/view/1');

// After - also supports arrays
$this->Htmx->redirect(['controller' => 'Posts', 'action' => 'view', 1]);
```

### Additional Changes
- Fixed PHPUnit XML configuration deprecation warning